### PR TITLE
Add emitter callback and set buffer size to 1 in NodeJS example

### DIFF
--- a/express/src/tracking/snowplow.ts
+++ b/express/src/tracking/snowplow.ts
@@ -1,5 +1,21 @@
-import { tracker, gotEmitter, HttpProtocol } from "@snowplow/node-tracker";
+import { tracker, gotEmitter, HttpProtocol, HttpMethod } from "@snowplow/node-tracker";
 
-const emitter = gotEmitter("0.0.0.0", HttpProtocol.HTTPS, 9090);
+const emitter = gotEmitter(
+  "0.0.0.0",
+  HttpProtocol.HTTPS,
+  9090,
+  HttpMethod.POST,
+  1, // buffer size – 1 means that each event is sent right away, without buffering
+  5,
+  undefined,
+  function (error, response) {
+    // Callback called for each request
+    if (error) {
+      console.log(error, "Request error");
+    } else {
+      console.log("Event Sent");
+    }
+  }
+);
 
 export const expressTracker = tracker(emitter, "myTracker", "myApp", false);


### PR DESCRIPTION
Makes it a bit easier to get the Express example to send events by:

1. setting the buffer size to 1 so that each event is sent right away
2. adding a callback which logs whether the request was sent or not