### PR TITLE
Add in-app tracker configuration and publish the React app on Github pages for this repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: publish
+
+on:
+  push:
+   branches:
+     - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - run: |
+      - run: |
+          cd react
+          yarn install
+          yarn build
+
+          # replace the base href to account for the /snowplow-javascript-tracker-examples/ path
+          sed -i 's/href="\//href="\/snowplow-javascript-tracker-examples\//g' build/index.html
+          sed -i 's/src="\//src="\/snowplow-javascript-tracker-examples\//g' build/index.html
+
+          # create a new directory and index.html for each route in the app
+          for path in form snowplow iframe_form youtube youtube_player; do
+            mkdir build/${path}
+            cp build/index.html build/${path}/index.html
+          done
+
+          # commit to gh-pages branch and push
+          git --work-tree build add --all
+          git commit -m "Automatic Deploy action run by github-actions"
+          git push origin HEAD:gh-pages --force

--- a/react/public/index.html
+++ b/react/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Snowplow JavaScript Tracker Demo</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -2,6 +2,8 @@ import './App.css';
 import { Link } from "react-router-dom";
 import { useLocationChange } from './tracker';
 import { enableAnonymousTracking, disableAnonymousTracking, trackStructEvent } from '@snowplow/browser-tracker';
+import CreateTrackerWrapper from "./createTrackerWrapper";
+import { getPath } from './helpers';
 
 function handleEnableAnonymousTracking() {
   enableAnonymousTracking({
@@ -33,11 +35,11 @@ function App() {
     <div className="App">
       <h1>Welcome!</h1>
       <dl>
-        <dt><Link to="/snowplow">About Snowplow</Link></dt>
-        <dt><Link to="/form">Form tracking demo</Link></dt>
-        <dt><Link to="/iframe_form">Form tracking demo in iframe</Link></dt>
-        <dt><Link to="/youtube">Youtube video tracking from Iframe</Link></dt>
-        <dt><Link to="/youtube_player">Youtube video tracking with YouTube Iframe API Player</Link></dt>
+        <dt><Link to={getPath("snowplow")}>About Snowplow</Link></dt>
+        <dt><Link to={getPath("form")}>Form tracking demo</Link></dt>
+        <dt><Link to={getPath("iframe_form")}>Form tracking demo in iframe</Link></dt>
+        <dt><Link to={getPath("youtube")}>Youtube video tracking from Iframe</Link></dt>
+        <dt><Link to={getPath("youtube_player")}>Youtube video tracking with YouTube Iframe API Player</Link></dt>
       </dl>
 
       <p>
@@ -55,4 +57,12 @@ function App() {
   );
 }
 
-export default App;
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <App />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/createTrackerWrapper.jsx
+++ b/react/src/createTrackerWrapper.jsx
@@ -1,0 +1,83 @@
+import './App.css';
+import { initializeTracker, isTrackerInitialized } from './tracker';
+import { useState } from "react";
+
+function submitForm(event) {
+  event.preventDefault();
+  const form = event.target;
+  const formData = new FormData(form);
+  const formValues = Object.fromEntries(formData.entries());
+
+  const endpoint = formValues.endpoint;
+  if (!endpoint) {
+    alert("Please enter a collector endpoint URI");
+    return false;
+  }
+
+  initializeTracker(endpoint);
+  localStorage.setItem("endpoint", endpoint);
+
+  return true;
+}
+
+function CreateTrackerWrapper({ children }) {
+  const [initialized, setInitialized] = useState(isTrackerInitialized());
+
+  if (initialized) {
+    return children;
+  }
+
+  return (
+    <div className="App">
+      <h1>Snowplow JavaScript Tracker Demo</h1>
+
+      <p>This is a demo of the browser tracker in a React app.</p>
+
+      <p>Use the form below to configure the tracker.</p>
+
+      <hr />
+
+      <form
+        onSubmit={(event) => {
+          if (submitForm(event)) {
+            setInitialized(true);
+          }
+        }}
+      >
+        <p>
+          <label htmlFor="endpoint">
+            <strong>Collector endpoint URI</strong> (you may use{" "}
+            <a href="https://docs.snowplow.io/docs/getting-started-with-micro/what-is-micro/">
+              Snowplow Micro
+            </a>{" "}
+            over <a href="https://ngrok.com/">ngrok</a>):
+          </label>
+          <input
+            type="text"
+            id="endpoint"
+            name="endpoint"
+            size="50"
+            placeholder="https://xxxx.ngrok-free.app"
+            defaultValue={localStorage.getItem("endpoint")}
+          />
+        </p>
+
+        <p>
+          <input className="button" type="submit" value="Create tracker" />
+          &nbsp;
+          <button
+            className="button"
+            onClick={() => {
+              initializeTracker("http://localhost:9090");
+              setInitialized(true);
+            }}
+          >
+            Skip
+          </button>
+        </p>
+      </form>
+    </div>
+  );
+}
+
+export default CreateTrackerWrapper;

--- a/react/src/helpers.js
+++ b/react/src/helpers.js
@@ -1,0 +1,8 @@
+export function getPath(path) {
+    const prefix = window.location.pathname.startsWith(
+      "/snowplow-javascript-tracker-examples"
+    )
+      ? "/snowplow-javascript-tracker-examples/"
+      : "/";
+    return prefix + path;
+}

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+label {
+  margin: 5px;
+}
+
+.button {
+  font-size: large;
+}

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -9,17 +9,18 @@ import IframeForm from "./routes/iframeForm";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Youtube from "./routes/youtube";
 import YoutubePlayer from "./routes/youtubePlayer.jsx";
+import { getPath } from "./helpers";
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="snowplow" element={<Snowplow />} />
-        <Route path="form" element={<Form />} />
-        <Route path="iframe_form" element={<IframeForm />} />
-        <Route path="youtube" element={<Youtube />} />
-        <Route path="youtube_player" element={<YoutubePlayer />} />
+        <Route path={getPath('')} element={<App />} />
+        <Route path={getPath("snowplow")} element={<Snowplow />} />
+        <Route path={getPath("form")} element={<Form />} />
+        <Route path={getPath("iframe_form")} element={<IframeForm />} />
+        <Route path={getPath("youtube")} element={<Youtube />} />
+        <Route path={getPath("youtube_player")} element={<YoutubePlayer />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/react/src/routes/form.jsx
+++ b/react/src/routes/form.jsx
@@ -2,8 +2,10 @@ import { useLocationChange } from '../tracker';
 import { Link } from 'react-router-dom';
 import { useEffect } from 'react';
 import { enableFormTracking } from '@snowplow/browser-plugin-form-tracking';
+import CreateTrackerWrapper from "../createTrackerWrapper";
+import { getPath } from '../helpers';
 
-export default function Form() {
+function Form() {
     useLocationChange();
     useEffect(() => {
         enableFormTracking({
@@ -19,7 +21,7 @@ export default function Form() {
             <h1>Form tracking demo</h1>
 
             <p>
-                <Link to="/">Go back</Link>
+                <Link to={getPath("")}>Go back</Link>
             </p>
 
             <form id="myForm" className="formy-mcformface" onSubmit={() => alert('Submitted')}>
@@ -58,3 +60,13 @@ export default function Form() {
         </div>
     );
 }
+
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <Form />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/routes/iframeForm.jsx
+++ b/react/src/routes/iframeForm.jsx
@@ -2,8 +2,10 @@ import { useLocationChange } from '../tracker';
 import { Link } from 'react-router-dom';
 import { useEffect } from 'react';
 import { enableFormTracking } from '@snowplow/browser-plugin-form-tracking';
+import CreateTrackerWrapper from "../createTrackerWrapper";
+import { getPath } from '../helpers';
 
-export default function IframeForm() {
+function IframeForm() {
     useLocationChange();
 
     useEffect(() => {
@@ -28,10 +30,20 @@ export default function IframeForm() {
             <h1>Form tracking demo</h1>
 
             <p>
-                <Link to="/">Go back</Link>
+                <Link to={getPath("")}>Go back</Link>
             </p>
 
             <iframe id="form_iframe" title="form_iframe" style={{width: 500, height: 500}}></iframe>
         </div>
     );
 }
+
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <IframeForm />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/routes/snowplow.jsx
+++ b/react/src/routes/snowplow.jsx
@@ -1,7 +1,8 @@
 import { useLocationChange } from '../tracker';
 import { Link } from "react-router-dom";
+import CreateTrackerWrapper from "../createTrackerWrapper";
 
-export default function Snowplow() {
+function Snowplow() {
   useLocationChange();
   return (
     <div className="App">
@@ -15,3 +16,13 @@ export default function Snowplow() {
     </div>
   );
 }
+
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <Snowplow />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/routes/youtube.jsx
+++ b/react/src/routes/youtube.jsx
@@ -1,7 +1,8 @@
 import { enableYouTubeTracking } from "@snowplow/browser-plugin-youtube-tracking";
 import React, { useEffect } from "react";
+import CreateTrackerWrapper from "../createTrackerWrapper";
 
-export default function YoutubeTrack() {
+function YoutubeTrack() {
   const videoId = "youtube";
 
   useEffect(() => {
@@ -26,3 +27,13 @@ export default function YoutubeTrack() {
     ></iframe>
   );
 }
+
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <YoutubeTrack />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/routes/youtubePlayer.jsx
+++ b/react/src/routes/youtubePlayer.jsx
@@ -1,5 +1,6 @@
 import { enableYouTubeTracking } from "@snowplow/browser-plugin-youtube-tracking";
 import React, { useEffect } from "react";
+import CreateTrackerWrapper from "../createTrackerWrapper";
 
 function loadVideoAndTrack(elemId, videoId) {
   new window.YT.Player(elemId, {
@@ -26,7 +27,7 @@ function loadYouTubeIframeAPI(elemId, videoId) {
   firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 }
 
-export default function YoutubeTrack() {
+function YoutubeTrack() {
   const elemId = "youtube";
   const videoId = "zSM4ZyVe8xs";
 
@@ -40,3 +41,13 @@ export default function YoutubeTrack() {
 
   return <div id={elemId}></div>;
 }
+
+function Wrapped() {
+  return (
+    <CreateTrackerWrapper>
+      <YoutubeTrack />
+    </CreateTrackerWrapper>
+  );
+}
+
+export default Wrapped;

--- a/react/src/tracker.js
+++ b/react/src/tracker.js
@@ -4,20 +4,28 @@ import { useLocation } from 'react-router-dom';
 import { FormTrackingPlugin } from '@snowplow/browser-plugin-form-tracking';
 import { YouTubeTrackingPlugin } from '@snowplow/browser-plugin-youtube-tracking';
 
-let tracker = newTracker('ns1', 'http://localhost:9090', {
-  plugins: [FormTrackingPlugin(), YouTubeTrackingPlugin()]
-});
+var tracker;
 
-enableActivityTracking({
-  minimumVisitLength: 5,
-  heartbeatDelay: 5
-});
+const initializeTracker = (endpoint) => {
+  tracker = newTracker('ns1', endpoint, {
+    plugins: [FormTrackingPlugin(), YouTubeTrackingPlugin()]
+  });
+
+  enableActivityTracking({
+    minimumVisitLength: 5,
+    heartbeatDelay: 5,
+  });
+}
 
 const useLocationChange = () => {
   const location = useLocation();
   React.useEffect(() => { 
-    trackPageView();
+    if (isTrackerInitialized()) {
+      trackPageView();
+    }
    }, [location]);
 };
 
-export { tracker, useLocationChange };
+const isTrackerInitialized = () => tracker !== undefined;
+
+export { tracker, initializeTracker, useLocationChange, isTrackerInitialized };


### PR DESCRIPTION
This PR adds a wrapper component around each route that lets the user enter the collector URI which will then be used to create the tracker. So instead of always tracking to `http://localhost:9090` the URI is now configurable in the app.

It also adds a Github action to publish the React demo app on Github Pages for this repository. The page is available here: https://snowplow-incubator.github.io/snowplow-javascript-tracker-examples/
It can be configured with an ngrok tunnel to a Snowplow Micro to track events from the demo app.